### PR TITLE
zlib1g-dev needs to run on compile time

### DIFF
--- a/recipes/chefgem.rb
+++ b/recipes/chefgem.rb
@@ -21,6 +21,9 @@
 
 include_recipe 'build-essential'
 include_recipe 'libxml2'
+package 'zlib1g-dev' do
+  action :nothing
+end.run_action(:install)
 
 chef_gem "nokogiri" do
   options node['nokogiri']['options']


### PR DESCRIPTION
on Ubuntu 12.04 and higher we need the zlib1g-dev package
and this package need to be installed at runtime because chef_gem runs at compile-time
this will change in chef 13 though
