### PR TITLE
Add compile_time to avoid 12.1.x errors

### DIFF
--- a/recipes/chefgem.rb
+++ b/recipes/chefgem.rb
@@ -25,4 +25,5 @@ include_recipe 'libxml2'
 chef_gem "nokogiri" do
   options node['nokogiri']['options']
   version node['nokogiri']['version']
+  compile_time true if Chef::Resource::ChefGem.instance_methods(false).include?(:compile_time)
 end


### PR DESCRIPTION
Starting in Chef 12.1.0, the `chef_gem` resource will throw a warning if `compile_time` is not specified. I added the `compile_time` attribute but also set a conditional since clients below 12.1.0 will not be able to handle this attribute. This is the recommended way, other than using `chef-sugar` to accomplish this task.

Before:

```
~/development/chef_nokogiri master$ rspec
[2015-03-24T07:06:13-05:00] WARN: chef_gem[nokogiri] chef_gem compile_time installation is deprecated
[2015-03-24T07:06:13-05:00] WARN: chef_gem[nokogiri] Please set `compile_time false` on the resource to use the new behavior.
[2015-03-24T07:06:13-05:00] WARN: chef_gem[nokogiri] or set `compile_time true` on the resource if compile_time behavior is required.
WARN: Unresolved specs during Gem::Specification.reset:
      nokogiri (>= 1.4.0, ~> 1.5)
WARN: Clearing out unresolved specs.
Please report a bug if this causes problems.
.[2015-03-24T07:06:13-05:00] WARN: chef_gem[nokogiri] chef_gem compile_time installation is deprecated
[2015-03-24T07:06:13-05:00] WARN: chef_gem[nokogiri] Please set `compile_time false` on the resource to use the new behavior.
[2015-03-24T07:06:13-05:00] WARN: chef_gem[nokogiri] or set `compile_time true` on the resource if compile_time behavior is required.
.[2015-03-24T07:06:14-05:00] WARN: chef_gem[nokogiri] chef_gem compile_time installation is deprecated
[2015-03-24T07:06:14-05:00] WARN: chef_gem[nokogiri] Please set `compile_time false` on the resource to use the new behavior.
[2015-03-24T07:06:14-05:00] WARN: chef_gem[nokogiri] or set `compile_time true` on the resource if compile_time behavior is required.
.[2015-03-24T07:06:14-05:00] WARN: chef_gem[nokogiri] chef_gem compile_time installation is deprecated
[2015-03-24T07:06:14-05:00] WARN: chef_gem[nokogiri] Please set `compile_time false` on the resource to use the new behavior.
[2015-03-24T07:06:14-05:00] WARN: chef_gem[nokogiri] or set `compile_time true` on the resource if compile_time behavior is required.
.[2015-03-24T07:06:14-05:00] WARN: chef_gem[nokogiri] chef_gem compile_time installation is deprecated
[2015-03-24T07:06:14-05:00] WARN: chef_gem[nokogiri] Please set `compile_time false` on the resource to use the new behavior.
[2015-03-24T07:06:14-05:00] WARN: chef_gem[nokogiri] or set `compile_time true` on the resource if compile_time behavior is required.
.[2015-03-24T07:06:14-05:00] WARN: chef_gem[nokogiri] chef_gem compile_time installation is deprecated
[2015-03-24T07:06:14-05:00] WARN: chef_gem[nokogiri] Please set `compile_time false` on the resource to use the new behavior.
[2015-03-24T07:06:14-05:00] WARN: chef_gem[nokogiri] or set `compile_time true` on the resource if compile_time behavior is required.
.[2015-03-24T07:06:14-05:00] WARN: chef_gem[nokogiri] chef_gem compile_time installation is deprecated
[2015-03-24T07:06:14-05:00] WARN: chef_gem[nokogiri] Please set `compile_time false` on the resource to use the new behavior.
[2015-03-24T07:06:14-05:00] WARN: chef_gem[nokogiri] or set `compile_time true` on the resource if compile_time behavior is required.
.[2015-03-24T07:06:15-05:00] WARN: chef_gem[nokogiri] chef_gem compile_time installation is deprecated
[2015-03-24T07:06:15-05:00] WARN: chef_gem[nokogiri] Please set `compile_time false` on the resource to use the new behavior.
[2015-03-24T07:06:15-05:00] WARN: chef_gem[nokogiri] or set `compile_time true` on the resource if compile_time behavior is required.
.[2015-03-24T07:06:15-05:00] WARN: chef_gem[nokogiri] chef_gem compile_time installation is deprecated
[2015-03-24T07:06:15-05:00] WARN: chef_gem[nokogiri] Please set `compile_time false` on the resource to use the new behavior.
[2015-03-24T07:06:15-05:00] WARN: chef_gem[nokogiri] or set `compile_time true` on the resource if compile_time behavior is required.
..........

Finished in 13.92 seconds (files took 7.46 seconds to load)
18 examples, 0 failures
```

After:

```
~/development/chef_nokogiri master$ rspec
WARN: Unresolved specs during Gem::Specification.reset:
      nokogiri (>= 1.4.0, ~> 1.5)
WARN: Clearing out unresolved specs.
Please report a bug if this causes problems.
..................

Finished in 5.21 seconds (files took 7.2 seconds to load)
18 examples, 0 failures

```
